### PR TITLE
fix: ChatClient cannot receive message

### DIFF
--- a/netty-learning/src/main/java/com/github/guang19/nettylearning/netty_chat/ChatServerHandler.java
+++ b/netty-learning/src/main/java/com/github/guang19/nettylearning/netty_chat/ChatServerHandler.java
@@ -14,7 +14,7 @@ import io.netty.util.concurrent.GlobalEventExecutor;
  */
 public class ChatServerHandler extends SimpleChannelInboundHandler<String>
 {
-    private final ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+    private static ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception


### PR DESCRIPTION
每个 ChatClient 进来都 new ChatServerHandler，由于 channelGroup 是实例成员，每个 ChatClient 都维护了一个自己的 channelGroup，导致后续 channelGroup.add(channel) 添加进分组不是同一个，向别的 ChatClient 发不了消息。
这里改成添加 static 将 channelGroup 改成类静态变量可解决。